### PR TITLE
fix: handle MCP SSE text/event-stream 400 error

### DIFF
--- a/internal/bootstrap/resolve.go
+++ b/internal/bootstrap/resolve.go
@@ -332,6 +332,9 @@ func shouldTreatSourceAsDirectMCPURL(source string, err error) bool {
 		if trimmed == "" {
 			return true
 		}
+		if strings.Contains(trimmed, "text/event-stream") {
+			return true
+		}
 		var raw map[string]any
 		if unmarshalErr := json.Unmarshal([]byte(trimmed), &raw); unmarshalErr == nil {
 			if _, ok := raw["jsonrpc"]; ok {

--- a/internal/bootstrap/resolve_helpers_test.go
+++ b/internal/bootstrap/resolve_helpers_test.go
@@ -142,6 +142,10 @@ func TestShouldTreatSourceAsDirectMCPURL(t *testing.T) {
 		t.Fatal("shouldTreatSourceAsDirectMCPURL(400 non-jsonrpc body) = true, want false")
 	}
 
+	if !shouldTreatSourceAsDirectMCPURL("https://example.com/mcp", &httpStatusError{statusCode: http.StatusBadRequest, body: "Accept must contain 'text/event-stream' for GET requests"}) {
+		t.Fatal("shouldTreatSourceAsDirectMCPURL(400 text/event-stream body) = false, want true")
+	}
+
 	if shouldTreatSourceAsDirectMCPURL("https://example.com/mcp", errors.New("generic fetch failure")) {
 		t.Fatal("shouldTreatSourceAsDirectMCPURL(generic error) = true, want false")
 	}

--- a/internal/bootstrap/resolve_test.go
+++ b/internal/bootstrap/resolve_test.go
@@ -370,6 +370,25 @@ func TestResolveHTTPURLFallsBackToDirectMCPWhenBodyIsNonManifestJSON(t *testing.
 	}
 }
 
+func TestResolveHTTPURLFallsBackToDirectMCPOn400TextEventStream(t *testing.T) {
+	source := "https://example.com/mcp"
+	resolved, err := Resolve(context.Background(), source, ResolveOptions{
+		FetchURL: func(context.Context, string) ([]byte, error) {
+			return nil, &httpStatusError{statusCode: 400, body: "Accept must contain 'text/event-stream' for GET requests"}
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+
+	if resolved.Name != "example" {
+		t.Fatalf("resolved.Name = %q, want %q", resolved.Name, "example")
+	}
+	if resolved.Server.URL != source {
+		t.Fatalf("resolved.Server.URL = %q, want %q", resolved.Server.URL, source)
+	}
+}
+
 func TestResolveHTTPURLFallsBackToDirectMCPWhenBodyIsProblemDetailsJSON(t *testing.T) {
 	source := "https://example.com/mcp"
 	resolved, err := Resolve(context.Background(), source, ResolveOptions{


### PR DESCRIPTION
## Problem

MCP servers using `modelcontextprotocol/go-sdk` Streamable HTTP transport return HTTP 400 when the initial GET request doesn't include proper Accept headers:

```
resolving source "http://xxx.com/mcp": fetching "http://xxx.com/mcp": unexpected HTTP status 400
```

Error source: https://github.com/modelcontextprotocol/go-sdk/blob/ea161959d7c87bd3d4bbd63cfa8df01d3ab3b304/mcp/streamable.go#L292

The server returns:
- Status: `400 Bad Request`
- Body: `Accept must contain 'text/event-stream' for GET requests`

## Solution

Add detection for `text/event-stream` in the 400 response body to trigger direct MCP URL resolution, consistent with existing handling for 401/403/405 status codes.

## Changes

- `internal/bootstrap/resolve.go` - Check for `text/event-stream` in 400 error body
- `internal/bootstrap/resolve_helpers_test.go` - Add test case for the new behavior