### PR TITLE
fix(config): skip merging fallback servers when managed servers exist

### DIFF
--- a/internal/config/fallback.go
+++ b/internal/config/fallback.go
@@ -95,6 +95,9 @@ func MergeFallbackServersForCWD(cfg *Config, cwd string) error {
 	if cfg == nil {
 		return nil
 	}
+	if len(cfg.Servers) > 0 {
+		return nil
+	}
 
 	fallback, err := loadFallbackServersWithSourcesForCWD(fallbackSourcePathsForCWD(cfg, cwd), cwd)
 	if len(fallback) > 0 {

--- a/internal/config/fallback_test.go
+++ b/internal/config/fallback_test.go
@@ -85,7 +85,7 @@ func TestMergeFallbackServersUsesFallbackWhenConfigEmpty(t *testing.T) {
 	}
 }
 
-func TestMergeFallbackServersKeepsManagedAndAddsDiscovered(t *testing.T) {
+func TestMergeFallbackServersKeepsManagedOnlyWhenConfigured(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -101,7 +101,7 @@ func TestMergeFallbackServersKeepsManagedAndAddsDiscovered(t *testing.T) {
 
 	raw := []byte(`{"mcpServers":{
 		"github":{"command":"npx","args":["-y","@modelcontextprotocol/server-github"]},
-		"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","."]}
+		"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem", "."]}
 	}}`)
 	if err := os.WriteFile(fallbackPath, raw, 0600); err != nil {
 		t.Fatalf("write fallback file: %v", err)
@@ -126,15 +126,10 @@ func TestMergeFallbackServersKeepsManagedAndAddsDiscovered(t *testing.T) {
 	if origin := cfg.ServerOrigins["github"]; origin.Kind != ServerOriginKindMCPXConfig {
 		t.Fatalf("managed origin kind = %q, want %q", origin.Kind, ServerOriginKindMCPXConfig)
 	}
-
-	if _, ok := cfg.Servers["filesystem"]; !ok {
-		t.Fatalf("cfg.Servers = %#v, want discovered filesystem server", cfg.Servers)
-	}
-	if origin := cfg.ServerOrigins["filesystem"]; origin.Kind == ServerOriginKindMCPXConfig {
-		t.Fatalf("filesystem origin kind = %q, want discovered source kind", origin.Kind)
+	if _, ok := cfg.Servers["filesystem"]; ok {
+		t.Fatalf("cfg.Servers = %#v, want no discovered servers when managed config exists", cfg.Servers)
 	}
 }
-
 func TestMergeFallbackServersUsesConfiguredSources(t *testing.T) {
 	customPath := filepath.Join(t.TempDir(), "custom-mcp.json")
 	raw := []byte(`{"mcpServers":{"custom":{"command":"uvx","args":["mcp-custom"]}}}`)


### PR DESCRIPTION
### Motivation
- Prevent untrusted fallback files (e.g. project-scoped `.mcp.json`) from injecting server names that can shadow internal CLI commands and cause unintended tool execution when the user already has managed servers configured. 
- Restore the original safety boundary where fallback discovery is only used for zero-config onboarding and does not override or extend an explicit managed config.

### Description
- Added an early return in `MergeFallbackServersForCWD` to skip loading/merging fallback sources when `cfg.Servers` is non-empty (`internal/config/fallback.go`).
- Updated the merge test to assert that when managed servers are present no discovered fallback servers are added (`TestMergeFallbackServersKeepsManagedOnlyWhenConfigured` in `internal/config/fallback_test.go`).
- Preserved existing behavior for empty configs and explicit `FallbackSources` overrides so existing onboarding and configured-source semantics remain unchanged.

### Testing
- Ran `go test ./internal/config -run MergeFallback -count=1`, which passed.  
- Ran `go vet ./...` and `go build ./...`, both of which passed.  
- Ran `go test ./...` which fails in this environment due to pre-existing `internal/config` Codex-related tests (`TestLoadCodexConfigFileAddsCodexAppsServerFromAuthFile` and `TestLoadCodexConfigFileCodexAppsUsesConnectorsTokenEnv`) that are unrelated to the fallback merge change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abab00c2ac8327bc6ef798dcebef5a)