### PR TITLE
fix: avoid codex apps probing during server listing

### DIFF
--- a/internal/daemon/daemon_tools_test.go
+++ b/internal/daemon/daemon_tools_test.go
@@ -3,7 +3,6 @@ package daemon
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -171,7 +170,7 @@ func TestToolSchemaPayloadUsesNativeToolName(t *testing.T) {
 	}
 }
 
-func TestListServersHidesCodexAppsAndShowsVirtualServers(t *testing.T) {
+func TestListServersHidesCodexAppsWithoutDiscovery(t *testing.T) {
 	cfg := &config.Config{
 		Servers: map[string]config.ServerConfig{
 			"github":            {},
@@ -186,62 +185,11 @@ func TestListServersHidesCodexAppsAndShowsVirtualServers(t *testing.T) {
 	ka := NewKeepalive(nil)
 	defer ka.Stop()
 
-	deps := runtimeDefaultDeps()
-	deps.poolListTools = func(_ context.Context, _ *mcppool.Pool, server string) ([]mcppool.ToolInfo, error) {
-		if server != codexAppsServerName {
-			t.Fatalf("poolListTools server = %q, want %q", server, codexAppsServerName)
-		}
-		return []mcppool.ToolInfo{
-			{Name: "linear_get_profile"},
-			{Name: "zillow_get_zestimate"},
-			{Name: "google calendar_search"},
-		}, nil
-	}
-
-	resp := listServersWithDeps(context.Background(), cfg, nil, ka, false, deps)
-	if resp.ExitCode != ipc.ExitOK {
-		t.Fatalf("listServers() exit = %d, want %d", resp.ExitCode, ipc.ExitOK)
-	}
-
-	got := decodeServerLines(resp.Content)
-	want := []string{"github", "google_calendar", "linear", "supermemory", "zillow"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("server list = %#v, want %#v", got, want)
-	}
-	entries := decodeServerEntries(resp.Content)
-	for _, entry := range entries {
-		switch entry.Name {
-		case "github", "supermemory":
-			if entry.Origin.Kind != config.ServerOriginKindMCPXConfig {
-				t.Fatalf("server %q origin kind = %q, want %q", entry.Name, entry.Origin.Kind, config.ServerOriginKindMCPXConfig)
-			}
-		case "google_calendar", "linear", "zillow":
-			if entry.Origin.Kind != config.ServerOriginKindCodexApps {
-				t.Fatalf("server %q origin kind = %q, want %q", entry.Name, entry.Origin.Kind, config.ServerOriginKindCodexApps)
-			}
-		}
-	}
-	for _, name := range got {
-		if name == codexAppsServerName {
-			t.Fatalf("server list = %#v, want %q omitted", got, codexAppsServerName)
-		}
-	}
-}
-
-func TestListServersKeepsConfiguredServersWhenCodexAppsDiscoveryFails(t *testing.T) {
-	cfg := &config.Config{
-		Servers: map[string]config.ServerConfig{
-			"github":            {},
-			codexAppsServerName: {},
-			"supermemory":       {},
-		},
-	}
-	ka := NewKeepalive(nil)
-	defer ka.Stop()
-
+	calls := 0
 	deps := runtimeDefaultDeps()
 	deps.poolListTools = func(_ context.Context, _ *mcppool.Pool, _ string) ([]mcppool.ToolInfo, error) {
-		return nil, errors.New("token expired")
+		calls++
+		return nil, nil
 	}
 
 	resp := listServersWithDeps(context.Background(), cfg, nil, ka, false, deps)
@@ -260,8 +208,55 @@ func TestListServersKeepsConfiguredServersWhenCodexAppsDiscoveryFails(t *testing
 			t.Fatalf("server %q origin kind = %q, want %q", entry.Name, entry.Origin.Kind, config.ServerOriginKindMCPXConfig)
 		}
 	}
-	if !strings.Contains(resp.Stderr, "failed to enumerate codex apps") {
-		t.Fatalf("listServers() stderr = %q, want codex-apps warning", resp.Stderr)
+	if calls != 0 {
+		t.Fatalf("codex list-tools calls = %d, want 0", calls)
+	}
+	for _, name := range got {
+		if name == codexAppsServerName {
+			t.Fatalf("server list = %#v, want %q omitted", got, codexAppsServerName)
+		}
+	}
+}
+
+func TestListServersKeepsConfiguredServersWhenCodexAppsConfigured(t *testing.T) {
+	cfg := &config.Config{
+		Servers: map[string]config.ServerConfig{
+			"github":            {},
+			codexAppsServerName: {},
+			"supermemory":       {},
+		},
+	}
+	ka := NewKeepalive(nil)
+	defer ka.Stop()
+
+	calls := 0
+	deps := runtimeDefaultDeps()
+	deps.poolListTools = func(_ context.Context, _ *mcppool.Pool, _ string) ([]mcppool.ToolInfo, error) {
+		calls++
+		return nil, nil
+	}
+
+	resp := listServersWithDeps(context.Background(), cfg, nil, ka, false, deps)
+	if resp.ExitCode != ipc.ExitOK {
+		t.Fatalf("listServers() exit = %d, want %d", resp.ExitCode, ipc.ExitOK)
+	}
+
+	got := decodeServerLines(resp.Content)
+	want := []string{"github", "supermemory"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("server list = %#v, want %#v", got, want)
+	}
+	entries := decodeServerEntries(resp.Content)
+	for _, entry := range entries {
+		if entry.Origin.Kind != config.ServerOriginKindMCPXConfig {
+			t.Fatalf("server %q origin kind = %q, want %q", entry.Name, entry.Origin.Kind, config.ServerOriginKindMCPXConfig)
+		}
+	}
+	if resp.Stderr != "" {
+		t.Fatalf("listServers() stderr = %q, want empty", resp.Stderr)
+	}
+	if calls != 0 {
+		t.Fatalf("codex list-tools calls = %d, want 0", calls)
 	}
 }
 

--- a/internal/servercatalog/catalog.go
+++ b/internal/servercatalog/catalog.go
@@ -38,6 +38,7 @@ func New(cfg *config.Config, listTools ListToolsFunc) *Catalog {
 }
 
 func (c *Catalog) ServerNames(ctx context.Context) ([]string, error) {
+	_ = ctx
 	if c == nil || c.cfg == nil {
 		return nil, nil
 	}
@@ -48,25 +49,6 @@ func (c *Catalog) ServerNames(ctx context.Context) ([]string, error) {
 			continue
 		}
 		names[name] = struct{}{}
-	}
-
-	if c.hasCodexApps() {
-		if c.listTools == nil {
-			return nil, fmt.Errorf("codex apps discovery requires list tools callback")
-		}
-		tools, err := c.listTools(ctx, CodexAppsServerName)
-		if err != nil {
-			return nil, err
-		}
-		for name := range codexVirtualServerMap(tools) {
-			if strings.TrimSpace(name) == "" {
-				continue
-			}
-			if _, exists := c.cfg.Servers[name]; exists {
-				continue
-			}
-			names[name] = struct{}{}
-		}
 	}
 
 	out := make([]string, 0, len(names))

--- a/internal/servercatalog/catalog_test.go
+++ b/internal/servercatalog/catalog_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lydakis/mcpx/internal/mcppool"
 )
 
-func TestServerNamesHidesCodexAppsAndAddsVirtualApps(t *testing.T) {
+func TestServerNamesHidesCodexAppsWithoutDiscovery(t *testing.T) {
 	cfg := &config.Config{
 		Servers: map[string]config.ServerConfig{
 			"playwright":        {},
@@ -18,15 +18,10 @@ func TestServerNamesHidesCodexAppsAndAddsVirtualApps(t *testing.T) {
 		},
 	}
 
-	catalog := New(cfg, func(_ context.Context, server string) ([]mcppool.ToolInfo, error) {
-		if server != CodexAppsServerName {
-			t.Fatalf("listTools server = %q, want %q", server, CodexAppsServerName)
-		}
-		return []mcppool.ToolInfo{
-			{Name: "linear_get_profile"},
-			{Name: "zillow_get_zestimate"},
-			{Name: "google calendar_search"},
-		}, nil
+	calls := 0
+	catalog := New(cfg, func(_ context.Context, _ string) ([]mcppool.ToolInfo, error) {
+		calls++
+		return nil, nil
 	})
 
 	names, err := catalog.ServerNames(context.Background())
@@ -34,9 +29,12 @@ func TestServerNamesHidesCodexAppsAndAddsVirtualApps(t *testing.T) {
 		t.Fatalf("ServerNames() error = %v", err)
 	}
 
-	want := []string{"google_calendar", "linear", "playwright", "supermemory", "zillow"}
+	want := []string{"playwright", "supermemory"}
 	if !reflect.DeepEqual(names, want) {
 		t.Fatalf("ServerNames() = %#v, want %#v", names, want)
+	}
+	if calls != 0 {
+		t.Fatalf("codex list-tools calls = %d, want 0", calls)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Server listing previously performed Codex apps discovery which invoked `listTools` for `codex_apps`, allowing stdio transports to be spawned during mere `list_servers`/CLI completion and creating an execution-on-list regression. 
- The intent is to restore the prior contract that listing servers is a config-only operation and must not connect to or launch tools.

### Description
- Remove Codex apps tool enumeration from `Catalog.ServerNames` so `ServerNames` no longer calls the `listTools` callback and therefore will not trigger MCP connections for `codex_apps` (`internal/servercatalog/catalog.go`).
- Preserve Codex discovery for resolution and tool lookup paths so virtual server resolution still works when explicitly requested (`Catalog.Resolve` remains unchanged).
- Update tests to assert server listing does not invoke codex discovery and emits no warning: adjust `internal/servercatalog/catalog_test.go` and `internal/daemon/daemon_tools_test.go` to expect only configured servers and zero `list-tools` calls during listing, and remove an unused import in the daemon test.

### Testing
- Ran the full test suite with the Codex runtime env disabled using `env -u CODEX_HOME go test ./...`, and all packages passed after the changes (tests previously failed before fixes).
- Ran `env -u CODEX_HOME go vet ./...` with no issues reported.
- Ran `env -u CODEX_HOME go build ./...` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ababdd13e88327b58df6eade123773)