### PR TITLE
Disable automatic CWD project fallback config discovery

### DIFF
--- a/internal/config/fallback.go
+++ b/internal/config/fallback.go
@@ -496,28 +496,6 @@ func isWithinPath(path, root string) bool {
 	return strings.HasPrefix(path, root+string(os.PathSeparator))
 }
 
-func nearestUpwardPath(relPath, cwd string) string {
-	base := resolveWorkingDirectory(cwd)
-	if base == "" {
-		return ""
-	}
-
-	dir := base
-	for {
-		candidate := filepath.Join(dir, relPath)
-		info, err := os.Stat(candidate)
-		if err == nil && !info.IsDir() {
-			return candidate
-		}
-
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			return ""
-		}
-		dir = parent
-	}
-}
-
 func fallbackSourcePaths(cfg *Config) []string {
 	return fallbackSourcePathsForCWD(cfg, "")
 }
@@ -534,6 +512,8 @@ func defaultFallbackSourcePaths() []string {
 }
 
 func defaultFallbackSourcePathsForCWD(cwd string) []string {
+	_ = cwd
+
 	home, _ := os.UserHomeDir()
 	if home == "" {
 		return nil
@@ -547,9 +527,7 @@ func defaultFallbackSourcePathsForCWD(cwd string) []string {
 			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"),
 			filepath.Join(home, ".claude.json"),
 			filepath.Join(home, ".codex", "config.toml"),
-			nearestUpwardPath(".mcp.json", cwd),
 			filepath.Join(home, ".kiro", "settings", "mcp.json"),
-			nearestUpwardPath(filepath.Join(".kiro", "settings", "mcp.json"), cwd),
 		}
 	case "linux":
 		return []string{
@@ -558,9 +536,7 @@ func defaultFallbackSourcePathsForCWD(cwd string) []string {
 			filepath.Join(home, ".config", "Code", "User", "globalStorage", "saoudrizwan.claude-dev", "settings", "cline_mcp_settings.json"),
 			filepath.Join(home, ".claude.json"),
 			filepath.Join(home, ".codex", "config.toml"),
-			nearestUpwardPath(".mcp.json", cwd),
 			filepath.Join(home, ".kiro", "settings", "mcp.json"),
-			nearestUpwardPath(filepath.Join(".kiro", "settings", "mcp.json"), cwd),
 		}
 	default:
 		return nil

--- a/internal/config/fallback_test.go
+++ b/internal/config/fallback_test.go
@@ -449,6 +449,7 @@ bearer_token_env_var = "REMOTE_TOKEN"
 }
 
 func TestLoadCodexConfigFileAddsCodexAppsServerFromAuthFile(t *testing.T) {
+	t.Setenv("CODEX_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 
@@ -492,6 +493,7 @@ apps = true
 }
 
 func TestLoadCodexConfigFileCodexAppsUsesConnectorsTokenEnv(t *testing.T) {
+	t.Setenv("CODEX_HOME", "")
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv(codexConnectorsTokenEnvVar, "connectors-999")
@@ -730,43 +732,6 @@ func TestLoadMCPServersFileReadsClaudeCodeProjectServers(t *testing.T) {
 	}
 }
 
-func TestNearestUpwardPathFindsNearestParent(t *testing.T) {
-	root := t.TempDir()
-	parent := filepath.Join(root, "parent")
-	child := filepath.Join(parent, "child")
-	grandChild := filepath.Join(child, "grandchild")
-	if err := os.MkdirAll(grandChild, 0700); err != nil {
-		t.Fatalf("mkdir grandchild: %v", err)
-	}
-
-	nearest := filepath.Join(child, ".mcp.json")
-	farther := filepath.Join(parent, ".mcp.json")
-	for _, path := range []string{nearest, farther} {
-		if err := os.WriteFile(path, []byte(`{"mcpServers":{}}`), 0600); err != nil {
-			t.Fatalf("write %s: %v", path, err)
-		}
-	}
-
-	prevWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(prevWD)
-	})
-	if err := os.Chdir(grandChild); err != nil {
-		t.Fatalf("chdir grandchild: %v", err)
-	}
-
-	if got := nearestUpwardPath(".mcp.json", ""); got != nearest {
-		gotResolved, gotErr := filepath.EvalSymlinks(got)
-		wantResolved, wantErr := filepath.EvalSymlinks(nearest)
-		if gotErr != nil || wantErr != nil || gotResolved != wantResolved {
-			t.Fatalf("nearestUpwardPath(.mcp.json) = %q, want %q", got, nearest)
-		}
-	}
-}
-
 func TestMergeFallbackServersForCWDUsesProvidedWorkingDirectory(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -791,17 +756,6 @@ func TestMergeFallbackServersForCWDUsesProvidedWorkingDirectory(t *testing.T) {
 		t.Fatalf("write project-b config: %v", err)
 	}
 
-	prevWD, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() {
-		_ = os.Chdir(prevWD)
-	})
-	if err := os.Chdir(projectASubdir); err != nil {
-		t.Fatalf("chdir project-a subdir: %v", err)
-	}
-
 	paths := fallbackSourcePathsForCWD(nil, projectBSubdir)
 	if len(paths) == 0 {
 		t.Skip("no fallback source paths for this platform")
@@ -811,11 +765,11 @@ func TestMergeFallbackServersForCWDUsesProvidedWorkingDirectory(t *testing.T) {
 	if err := MergeFallbackServersForCWD(cfg, projectBSubdir); err != nil {
 		t.Fatalf("MergeFallbackServersForCWD() error = %v", err)
 	}
-	if _, ok := cfg.Servers["server-b"]; !ok {
-		t.Fatalf("cfg.Servers = %#v, want server-b from provided cwd", cfg.Servers)
+	if _, ok := cfg.Servers["server-b"]; ok {
+		t.Fatalf("cfg.Servers = %#v, want project-local server excluded", cfg.Servers)
 	}
 	if _, ok := cfg.Servers["server-a"]; ok {
-		t.Fatalf("cfg.Servers = %#v, want server-a excluded", cfg.Servers)
+		t.Fatalf("cfg.Servers = %#v, want project-local server excluded", cfg.Servers)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- The daemon previously performed CWD-aware upward discovery of project-local fallback files (e.g. nearest parent `.mcp.json` and `.kiro/settings/mcp.json`), which allowed untrusted repositories to inject MCP server definitions and enlarged the RCE/SSRF attack surface. 
- The change aims to eliminate silent import of attacker-controlled project configs while preserving explicit user/home-level fallback sources.

### Description

- Removed automatic upward project-local discovery from the default fallback source list by eliminating calls to `nearestUpwardPath(...)` in `defaultFallbackSourcePathsForCWD` and removing the now-unused `nearestUpwardPath` behavior in `internal/config/fallback.go`. 
- Kept user/home-level fallback sources such as `~/.cursor/mcp.json`, `~/.claude.json`, and `~/.codex/config.toml` intact to preserve expected default behavior. 
- Updated tests in `internal/config/fallback_test.go` to reflect that project-local configs are no longer auto-discovered and removed the `TestNearestUpwardPathFindsNearestParent` unit test that validated upward discovery. 
- Made two Codex-related tests deterministic by explicitly clearing `CODEX_HOME` within the test (`t.Setenv("CODEX_HOME", "")`) so auth file resolution is not environment-dependent.

### Testing

- Ran `go test ./...` and all packages passed after test updates (`internal/config` and the rest of the repo succeeded). 
- Ran `go vet ./...` and `go build ./...` and both completed without errors. 
- Existing and modified unit tests in `internal/config` were executed and validate the new behavior (no project-local upward discovery by default).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abadc3619483279dfbde1c529ddd26)